### PR TITLE
Supports weights other than for TensorFlow saved models

### DIFF
--- a/src/main/java/io/bioimage/specification/io/SpecificationReaderWriterV4.java
+++ b/src/main/java/io/bioimage/specification/io/SpecificationReaderWriterV4.java
@@ -30,7 +30,9 @@ package io.bioimage.specification.io;
 
 import io.bioimage.specification.*;
 import io.bioimage.specification.transformation.*;
+import io.bioimage.specification.weights.OnnxWeightsSpecification;
 import io.bioimage.specification.weights.TensorFlowSavedModelBundleSpecification;
+import io.bioimage.specification.weights.TorchscriptWeightsSpecification;
 
 import java.io.IOException;
 import java.util.*;
@@ -62,6 +64,7 @@ class SpecificationReaderWriterV4 {
     private final static String idWeightsSource = "source";
     private final static String idWeightsHash = "sha256";
     private final static String idWeightsTag = "tag";
+    private final static String idWeightsOnnxOpsetVersion = "opset_version";
     private final static String idPackagedBy = "packaged_by";
     private final static String idDependencies = "dependencies";
     private final static String idType = "type";
@@ -121,7 +124,13 @@ class SpecificationReaderWriterV4 {
     private final static String idTransformationZeroMean = "zero_mean_unit_variance";
     private final static String idTransformationZeroMeanMean = "mean";
     private final static String idTransformationZeroMeanStd = "std";
+    
     private final static String idWeightsTensorFlowSavedModelBundle = "tensorflow_saved_model_bundle";
+    private final static String idWeightsTorchscript = "torchscript";
+    private final static String idWeightsPytorchStateDict = "pytorch_state_dict";
+    private final static String idWeightsKerasHDF5 = "keras_hdf5";
+    private final static String idWeightsTensorFlowJS = "tensorflow_js";
+    private final static String idWeightsOnnx = "onnx";
 
     private final static String idTransformationScaleMinMax = "scale_min_max";
     private final static String idTransformationScaleMinMaxReferenceInput = "reference_input";
@@ -285,14 +294,34 @@ class SpecificationReaderWriterV4 {
     }
 
     private static void readWeightsEntry(DefaultModelSpecification specification, String name, Map<String, Object> data) {
+    	WeightsSpecification weightsSpec = null;
         if (name.equals(idWeightsTensorFlowSavedModelBundle)) {
-            TensorFlowSavedModelBundleSpecification weightsSpec = new TensorFlowSavedModelBundleSpecification();
+            weightsSpec = new TensorFlowSavedModelBundleSpecification();
             if (data != null) {
-                weightsSpec.setTag((String) data.get(idWeightsTag));
-                weightsSpec.setSha256((String) data.get(idWeightsHash));
-                weightsSpec.setSource((String) data.get(idWeightsSource));
+                ((TensorFlowSavedModelBundleSpecification)weightsSpec).setTag((String) data.get(idWeightsTag));
             }
-            specification.addWeights(TensorFlowSavedModelBundleSpecification.id, weightsSpec);
+        } else if (name.equals(idWeightsOnnx)) {
+        	weightsSpec = new OnnxWeightsSpecification();
+        	if (data != null) {
+        		((OnnxWeightsSpecification)weightsSpec).setOpsetVersion((String) data.get(idWeightsOnnxOpsetVersion));
+        	}
+        } else if (name.equals(idWeightsTorchscript)) {
+        	weightsSpec = new TorchscriptWeightsSpecification();
+        } else if (Arrays.asList(
+        		idWeightsTensorFlowSavedModelBundle,
+        		idWeightsTensorFlowJS,
+        		idWeightsPytorchStateDict,
+        		idWeightsTorchscript,
+        		idWeightsKerasHDF5
+        		).contains(name)) {
+        	weightsSpec = new DefaultWeightsSpecification();
+        }
+        if (weightsSpec != null) {
+	        if (data != null) {
+	            weightsSpec.setSha256((String) data.get(idWeightsHash));
+	            weightsSpec.setSource((String) data.get(idWeightsSource));
+	        }
+	        specification.addWeights(name, weightsSpec);
         }
     }
 
@@ -453,10 +482,12 @@ class SpecificationReaderWriterV4 {
         if (config != null) data.put(idConfig, config);
     }
 
+    /* Unused?
     private static String getWeightsName(WeightsSpecification weight) {
         if (weight instanceof TensorFlowSavedModelBundleSpecification) return idWeightsTensorFlowSavedModelBundle;
         return null;
     }
+    */
 
     private static List<Map<String, Object>> buildTransformationList(List<TransformationSpecification> transformations) {
         List<Map<String, Object>> res = new ArrayList<>();

--- a/src/main/java/io/bioimage/specification/weights/OnnxWeightsSpecification.java
+++ b/src/main/java/io/bioimage/specification/weights/OnnxWeightsSpecification.java
@@ -26,68 +26,20 @@
  * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
-package io.bioimage.specification;
+package io.bioimage.specification.weights;
 
-import java.util.List;
-import java.util.Map;
+import io.bioimage.specification.DefaultWeightsSpecification;
 
-public class DefaultWeightsSpecification implements WeightsSpecification {
+public class OnnxWeightsSpecification extends DefaultWeightsSpecification {
 
-    private String source;
-    private String sha256;
-    private String parent;
-    private List<AuthorSpecification> authors;
-    private Map<String, String> attachments;
+	private String opsetVersion;
 
+	public String getOpsetVersion() {
+		return opsetVersion;
+	}
 
-    @Override
-    public String getSource() {
-        return source;
-    }
-
-    @Override
-    public void setSource(String source) {
-        this.source = source;
-    }
-
-    @Override
-    public String getSha256() {
-        return sha256;
-    }
-
-    @Override
-    public void setSha256(String sha256) {
-        this.sha256 = sha256;
-    }
-
-    @Override
-    public String getParent() {
-        return parent;
-    }
-
-    @Override
-    public void setParent(String parent) {
-        this.parent = parent;
-    }
-
-    @Override
-    public List<AuthorSpecification> getAuthors() {
-        return authors;
-    }
-
-    @Override
-    public void setAuthors(List<AuthorSpecification> authors) {
-        this.authors = authors;
-    }
-
-    @Override
-    public Map<String, String> getAttachments() {
-        return attachments;
-    }
-
-    @Override
-    public void setAttachments(Map<String, String> attachments) {
-        this.attachments = attachments;
-    }
+	public void setOpsetVersion(String opsetVersion) {
+		this.opsetVersion = opsetVersion;
+	}
 
 }

--- a/src/main/java/io/bioimage/specification/weights/TorchscriptWeightsSpecification.java
+++ b/src/main/java/io/bioimage/specification/weights/TorchscriptWeightsSpecification.java
@@ -26,68 +26,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
-package io.bioimage.specification;
+package io.bioimage.specification.weights;
 
-import java.util.List;
-import java.util.Map;
+import io.bioimage.specification.DefaultWeightsSpecification;
 
-public class DefaultWeightsSpecification implements WeightsSpecification {
-
-    private String source;
-    private String sha256;
-    private String parent;
-    private List<AuthorSpecification> authors;
-    private Map<String, String> attachments;
-
-
-    @Override
-    public String getSource() {
-        return source;
-    }
-
-    @Override
-    public void setSource(String source) {
-        this.source = source;
-    }
-
-    @Override
-    public String getSha256() {
-        return sha256;
-    }
-
-    @Override
-    public void setSha256(String sha256) {
-        this.sha256 = sha256;
-    }
-
-    @Override
-    public String getParent() {
-        return parent;
-    }
-
-    @Override
-    public void setParent(String parent) {
-        this.parent = parent;
-    }
-
-    @Override
-    public List<AuthorSpecification> getAuthors() {
-        return authors;
-    }
-
-    @Override
-    public void setAuthors(List<AuthorSpecification> authors) {
-        this.authors = authors;
-    }
-
-    @Override
-    public Map<String, String> getAttachments() {
-        return attachments;
-    }
-
-    @Override
-    public void setAttachments(Map<String, String> attachments) {
-        this.attachments = attachments;
-    }
-
-}
+public class TorchscriptWeightsSpecification extends DefaultWeightsSpecification {}


### PR DESCRIPTION
Adds basic support for other weight formats as described at https://github.com/bioimage-io/spec-bioimage-io/blob/main/supported_formats_and_operations.md#weight_format

This includes making DefaultWeightsSpecification non-abstract to avoid needing to define new classes for weight formats that contain no additional information. However TorchscriptWeightsSpecification is still given a new class because it corresponds to two different tags (pytorch_script for v0.3 and torchscript for v0.4).